### PR TITLE
Populate ticket fields from existing CPF

### DIFF
--- a/src/hooks/useUsuarios.ts
+++ b/src/hooks/useUsuarios.ts
@@ -83,5 +83,23 @@ export const useUsuarios = () => {
     }
   };
 
-  return { salvarUsuario, buscarUsuarios, loading };
+  const buscarUsuarioPorCPF = async (cpf: string): Promise<Usuario | null> => {
+    if (!cpf) return null;
+
+    try {
+      const { data, error } = await supabase
+        .from('usuarios')
+        .select('id, cpf, nome_completo, perfil')
+        .eq('cpf', cpf)
+        .maybeSingle();
+
+      if (error) throw error;
+      return data;
+    } catch (err) {
+      console.error('Erro ao buscar usuário por CPF:', err);
+      return null;
+    }
+  };
+
+  return { salvarUsuario, buscarUsuarios, buscarUsuarioPorCPF, loading };
 };


### PR DESCRIPTION
<!-- Implement automatic name and profile filling from existing CPF data, prioritizing the `usuarios` table. -->

<!-- The system now first checks the `usuarios` table for current user data when a CPF is entered. If no match is found, it falls back to searching the `chamados` table for historical data, ensuring the most accurate information is used for pre-filling. -->

---

[Open in Web](https://cursor.com/agents?id=bc-a44b1b8d-62f1-4e00-b9bc-5cc4865059aa) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a44b1b8d-62f1-4e00-b9bc-5cc4865059aa) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)