### PR TITLE
Fix weekly notification creation conflict

### DIFF
--- a/CORREÇÃO_NOTIFICAÇÕES_SEMANAIS.md
+++ b/CORREÇÃO_NOTIFICAÇÕES_SEMANAIS.md
@@ -1,0 +1,77 @@
+# Correção - Notificações Semanais
+
+## Problemas Identificados e Soluções
+
+### 1. Erro "Could not find the 'dayofweek' column"
+
+**Problema**: Inconsistência entre o nome da coluna no banco de dados (`dayOfWeek`) e o código TypeScript (`dayofweek`).
+
+**Solução**: 
+- Criada migração `/workspace/supabase/migrations/20250129000000_fix_dayofweek_column_name.sql` para renomear a coluna
+- Atualizado o arquivo `/workspace/src/integrations/supabase/types.ts` para incluir as colunas `dayofweek` e `time`
+
+### 2. Campos Duplicados na Interface
+
+**Problema**: Os campos "Dia da Semana" e "Horário" apareciam tanto no modal principal quanto no dialog de nova notificação, causando confusão.
+
+**Solução**: 
+- Removidos os campos de agendamento do modal principal (`WeeklyNotificationsManager.tsx`)
+- Mantidos apenas no dialog de nova/editar notificação (`WeeklyNotificationDialog.tsx`)
+- Adicionada visualização do agendamento nos cards das notificações existentes
+
+## Arquivos Modificados
+
+### 1. Migração do Banco de Dados
+```sql
+-- /workspace/supabase/migrations/20250129000000_fix_dayofweek_column_name.sql
+ALTER TABLE public.weekly_notifications 
+RENAME COLUMN "dayOfWeek" TO dayofweek;
+
+COMMENT ON COLUMN public.weekly_notifications.dayofweek IS 'Day of the week for notification (0 = Sunday, 1 = Monday, ..., 6 = Saturday)';
+```
+
+### 2. Tipos do Supabase
+- `/workspace/src/integrations/supabase/types.ts`: Adicionadas colunas `dayofweek` e `time`
+
+### 3. Interface do Usuário
+- `/workspace/src/components/weekly-notifications/WeeklyNotificationsManager.tsx`: 
+  - Removidos campos duplicados de agendamento
+  - Simplificada interface do modal principal
+  - Adicionada visualização do agendamento nos cards das notificações
+
+## Como Aplicar a Correção
+
+### 1. Se estiver usando Supabase Local
+```bash
+# Aplicar a migração no banco local
+npx supabase db reset --local
+```
+
+### 2. Se estiver usando Supabase em Produção
+Execute o seguinte SQL no Supabase Dashboard > SQL Editor:
+
+```sql
+-- Renomear coluna para consistência
+ALTER TABLE public.weekly_notifications 
+RENAME COLUMN "dayOfWeek" TO dayofweek;
+
+-- Atualizar comentário
+COMMENT ON COLUMN public.weekly_notifications.dayofweek IS 'Day of the week for notification (0 = Sunday, 1 = Monday, ..., 6 = Saturday)';
+```
+
+## Melhorias Implementadas
+
+1. **Interface mais limpa**: Campos de agendamento aparecem apenas onde são necessários
+2. **Consistência de dados**: Nome da coluna consistente entre banco e código
+3. **Melhor UX**: Usuário configura dia/hora diretamente ao criar cada notificação
+4. **Visualização clara**: Cards das notificações mostram quando cada uma será enviada
+
+## Testando a Correção
+
+1. Abra a seção "Notificações Semanais" 
+2. Clique em "Nova Notificação"
+3. Preencha os campos incluindo dia da semana e horário
+4. Salve a notificação
+5. Verifique se a notificação aparece na lista com o agendamento correto
+
+O erro "Could not find the 'dayofweek' column" deve estar resolvido, e não deve haver mais campos duplicados na interface.

--- a/src/components/weekly-notifications/WeeklyNotificationsManager.tsx
+++ b/src/components/weekly-notifications/WeeklyNotificationsManager.tsx
@@ -34,16 +34,6 @@ export const WeeklyNotificationsManager = () => {
     time: '09:00'
   });
 
-  const timeOptions = [
-    { value: '08:00', label: '08:00' },
-    { value: '09:00', label: '09:00' },
-    { value: '10:00', label: '10:00' },
-    { value: '11:00', label: '11:00' },
-    { value: '14:00', label: '14:00' },
-    { value: '15:00', label: '15:00' },
-    { value: '16:00', label: '16:00' },
-  ];
-
   const dayOptions = [
     { value: 1, label: 'Segunda-feira' },
     { value: 2, label: 'Terça-feira' },
@@ -199,70 +189,12 @@ export const WeeklyNotificationsManager = () => {
                 </div>
                 
                 {settings.enabled && (
-                  <div className="space-y-4 pt-4 border-t border-gray-200 dark:border-gray-600">
-                    <div className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-3 dark:text-gray-300">
-                      <Sparkles className="h-4 w-4 text-purple-500" />
-                      Configurações de Agendamento
-                    </div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                      <div className="space-y-3">
-                        <Label className="flex items-center gap-2 text-sm font-medium dark:text-gray-200">
-                          <Calendar className="h-4 w-4 text-blue-500" />
-                          Dia da Semana
-                        </Label>
-                        <Select 
-                          value={settings.dayofweek?.toString() || '1'}
-                onValueChange={(value) => saveSettings({ ...settings, dayofweek: parseInt(value) })}
-                        >
-                          <SelectTrigger className="h-11 border-2 hover:border-blue-300 transition-colors dark:border-gray-600 dark:hover:border-blue-500 dark:bg-gray-800">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {dayOptions.map((day) => (
-                              <SelectItem key={day.value} value={day.value.toString()} className="py-3">
-                                <div className="flex items-center gap-2">
-                                  <Calendar className="h-4 w-4 text-blue-500" />
-                                  {day.label}
-                                </div>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      
-                      <div className="space-y-3">
-                        <Label className="flex items-center gap-2 text-sm font-medium dark:text-gray-200">
-                          <Clock className="h-4 w-4 text-green-500" />
-                          Horário
-                        </Label>
-                        <Select 
-                          value={settings.time} 
-                          onValueChange={(value) => saveSettings({ ...settings, time: value })}
-                        >
-                          <SelectTrigger className="h-11 border-2 hover:border-green-300 transition-colors dark:border-gray-600 dark:hover:border-green-500 dark:bg-gray-800">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {timeOptions.map((time) => (
-                              <SelectItem key={time.value} value={time.value} className="py-3">
-                                <div className="flex items-center gap-2">
-                                  <Clock className="h-4 w-4 text-green-500" />
-                                  {time.label}
-                                </div>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </div>
-                    
-                    <div className="mt-4 p-3 bg-blue-50 rounded-lg border border-blue-200 dark:bg-blue-900/20 dark:border-blue-700">
-                      <div className="flex items-center gap-2 text-sm text-blue-700 dark:text-blue-300">
-                        <Bell className="h-4 w-4" />
-                        <span className="font-medium">
-                          Próxima notificação: {dayOptions.find(d => d.value === (settings.dayofweek || 1))?.label || 'Dia não definido'} às {settings.time || '09:00'}
-                        </span>
-                      </div>
+                  <div className="mt-4 p-3 bg-blue-50 rounded-lg border border-blue-200 dark:bg-blue-900/20 dark:border-blue-700">
+                    <div className="flex items-center gap-2 text-sm text-blue-700 dark:text-blue-300">
+                      <Bell className="h-4 w-4" />
+                      <span className="font-medium">
+                        Sistema de notificações ativo. Configure os horários individuais ao criar cada notificação.
+                      </span>
                     </div>
                   </div>
                 )}
@@ -368,6 +300,16 @@ export const WeeklyNotificationsManager = () => {
                           </p>
                         </div>
                         
+                        {/* Mostrar agendamento da notificação */}
+                        <div className="mb-3 p-2 bg-blue-50 rounded-md border border-blue-200 dark:bg-blue-900/20 dark:border-blue-700">
+                          <div className="flex items-center gap-2 text-xs text-blue-700 dark:text-blue-300">
+                            <Calendar className="h-3 w-3" />
+                            <span>{dayOptions.find(d => d.value === notification.dayofweek)?.label || 'Dia não definido'}</span>
+                            <Clock className="h-3 w-3 ml-2" />
+                            <span>{notification.time || '09:00'}</span>
+                          </div>
+                        </div>
+                        
                         <div className="flex items-center justify-between pt-3 border-t border-gray-200">
                           <div className="text-xs text-muted-foreground">
                             Criado em {new Date(notification.created_at).toLocaleDateString('pt-BR')}
@@ -423,7 +365,10 @@ export const WeeklyNotificationsManager = () => {
               <div className="text-sm text-muted-foreground">
                 {settings.enabled ? (
                   <span>
-                    Próxima notificação: {dayOptions.find(d => d.value === settings.dayofweek)?.label || 'Dia não definido'} às {settings.time}
+                    {activeNotifications.length > 0 
+                      ? `${activeNotifications.length} notificação${activeNotifications.length > 1 ? 'ões' : ''} ativa${activeNotifications.length > 1 ? 's' : ''}`
+                      : 'Nenhuma notificação ativa'
+                    }
                   </span>
                 ) : (
                   <span>Notificações desabilitadas</span>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -445,24 +445,30 @@ export type Database = {
         Row: {
           ativo: boolean | null
           created_at: string
+          dayofweek: number
           id: string
           mensagem: string
+          time: string
           titulo: string
           updated_at: string
         }
         Insert: {
           ativo?: boolean | null
           created_at?: string
+          dayofweek?: number
           id?: string
           mensagem: string
+          time?: string
           titulo: string
           updated_at?: string
         }
         Update: {
           ativo?: boolean | null
           created_at?: string
+          dayofweek?: number
           id?: string
           mensagem?: string
+          time?: string
           titulo?: string
           updated_at?: string
         }

--- a/supabase/migrations/20250129000000_fix_dayofweek_column_name.sql
+++ b/supabase/migrations/20250129000000_fix_dayofweek_column_name.sql
@@ -1,0 +1,8 @@
+-- Fix column name inconsistency: rename dayOfWeek to dayofweek
+-- This ensures consistency between database schema and TypeScript types
+
+ALTER TABLE public.weekly_notifications 
+RENAME COLUMN "dayOfWeek" TO dayofweek;
+
+-- Update the comment to reflect the correct column name
+COMMENT ON COLUMN public.weekly_notifications.dayofweek IS 'Day of the week for notification (0 = Sunday, 1 = Monday, ..., 6 = Saturday)';


### PR DESCRIPTION
Fix weekly notification creation by resolving a database column name inconsistency and simplifying the UI.

The PR resolves a `dayOfWeek` column name mismatch between the database and application code, which caused "Could not find column" errors. It also streamlines the weekly notifications UI by removing duplicate scheduling fields from the main settings modal, ensuring they are only configured per-notification.

---

[Open in Web](https://cursor.com/agents?id=bc-7ece42ec-5194-4933-b4f7-a4fd40fe5a23) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7ece42ec-5194-4933-b4f7-a4fd40fe5a23) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)