### PR TITLE
Fix process number field in create ticket

### DIFF
--- a/src/components/FormSection.tsx
+++ b/src/components/FormSection.tsx
@@ -21,6 +21,7 @@ import { useState, useEffect } from 'react';
 interface FormSectionProps {
   formData: FormData;
   onInputChange: (field: keyof FormData, value: string | boolean) => void;
+  onMultipleInputChange?: (updates: Partial<FormData>) => void;
   onGenerateDescription: () => void;
   onResetForm: () => void;
   onShowAIHistory?: () => void;
@@ -28,7 +29,7 @@ interface FormSectionProps {
   validationErrors?: Record<string, string>;
 }
 
-export const FormSection = ({ formData, onInputChange, onGenerateDescription, onResetForm, onShowAIHistory, onShowAISettings, validationErrors = {} }: FormSectionProps) => {
+export const FormSection = ({ formData, onInputChange, onMultipleInputChange, onGenerateDescription, onResetForm, onShowAIHistory, onShowAISettings, validationErrors = {} }: FormSectionProps) => {
   const { 
     buscarSugestoesOrgaoJulgador, 
     buscarSugestoesPerfil, 
@@ -72,15 +73,23 @@ export const FormSection = ({ formData, onInputChange, onGenerateDescription, on
   }, [formData.grau]);
 
   const handleProcessoChange = (value: string) => {
-    onInputChange('processos', value);
-    
     // Auto-preenchimento do órgão julgador para 1º grau
     if (formData.grau === '1º Grau' && value.trim()) {
       const orgaoJulgador = obterOrgaoJulgadorDoProcesso(value.trim());
-      if (orgaoJulgador) {
-        onInputChange('orgaoJulgador', orgaoJulgador);
+      
+      if (orgaoJulgador && onMultipleInputChange) {
+        // Use multiple input change to update both fields at once
+        // This prevents the race condition where processos field gets cleared
+        onMultipleInputChange({
+          processos: value,
+          orgaoJulgador: orgaoJulgador
+        });
+        return;
       }
     }
+    
+    // Fallback to single field update
+    onInputChange('processos', value);
   };
 
 

--- a/src/pages/CriarChamado.tsx
+++ b/src/pages/CriarChamado.tsx
@@ -220,6 +220,33 @@ const CriarChamado = () => {
      }, 3000); // Salvar após 3 segundos de inatividade
    };
 
+   const handleMultipleInputChange = (updates: Partial<FormData>) => {
+     const newFormData = {
+       ...formData,
+       ...updates
+     };
+     
+     setFormData(newFormData);
+     setIsGenerated(false);
+     setIsDirty(true);
+     
+     // Validação em tempo real para cada campo atualizado
+     Object.entries(updates).forEach(([field, value]) => {
+       if (typeof value === 'string' || typeof value === 'boolean') {
+         validateField(field as keyof FormData, value);
+       }
+     });
+     
+     // Configurar salvamento automático
+     if (autoSaveTimeoutRef.current) {
+       clearTimeout(autoSaveTimeoutRef.current);
+     }
+     
+     autoSaveTimeoutRef.current = setTimeout(() => {
+       autoSave(newFormData);
+     }, 3000); // Salvar após 3 segundos de inatividade
+   };
+
    // Cleanup do timeout
    useEffect(() => {
      return () => {
@@ -428,6 +455,7 @@ const CriarChamado = () => {
             <FormSection
           formData={formData}
           onInputChange={handleInputChange}
+          onMultipleInputChange={handleMultipleInputChange}
           onGenerateDescription={handleGenerateDescription}
           onResetForm={resetForm}
           onShowAIHistory={() => setShowAIHistory(true)}


### PR DESCRIPTION
Fixes "Número do Processo" field clearing issue by updating both process number and court organization in a single state operation to prevent a race condition.

Previously, when a process number was entered, two sequential `onInputChange` calls (one for the process number and one for the auto-filled court organization) created a race condition in React's state updates. This caused the "Número do Processo" field to be inadvertently cleared. The solution introduces an `onMultipleInputChange` prop to allow simultaneous updates of multiple form fields, ensuring both the process number and court organization are set correctly in one atomic state change.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae10acc0-f2ba-4310-a323-3c286d567ada">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae10acc0-f2ba-4310-a323-3c286d567ada">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>